### PR TITLE
[#35] Footer 카테고리 표시 문제 수정

### DIFF
--- a/docs/start/2_footer_todo.md
+++ b/docs/start/2_footer_todo.md
@@ -3,69 +3,69 @@
 ## Phase 1: 코드 수정
 
 ### Step 1: blog-client.ts 수정
-- [ ] `src/lib/blog-client.ts` 파일 열기
-- [ ] 21행 찾기: `const response = await fetch('/api/categories')`
-- [ ] 수정: `'/api/categories'` → `'/data/categories.json'`
-- [ ] 파일 저장
+- [x] `src/lib/blog-client.ts` 파일 열기
+- [x] 21행 찾기: `const response = await fetch('/api/categories')`
+- [x] 수정: `'/api/categories'` → `'/data/categories.json'`
+- [x] 파일 저장
 
 ### Step 2: footer.tsx 수정
-- [ ] `src/components/footer.tsx` 파일 열기
-- [ ] import 추가: `import { getAllCategoriesClient } from "@/lib/blog-client";`
-- [ ] 18-44행의 중복 fetch 로직 삭제
-- [ ] useEffect를 간단하게 변경: `getAllCategoriesClient().then(setCategories);`
-- [ ] 파일 저장
+- [x] `src/components/footer.tsx` 파일 열기
+- [x] import 추가: `import { getAllCategoriesClient } from "@/lib/blog-client";`
+- [x] 18-44행의 중복 fetch 로직 삭제
+- [x] useEffect를 간단하게 변경: `getAllCategoriesClient().then(setCategories);`
+- [x] 파일 저장
 
 ### Step 3: category-filter.tsx 수정
-- [ ] `src/components/category-filter.tsx` 파일 열기
-- [ ] 18행 수정: `queryKey: ['/api/categories']` → `queryKey: ['/data/categories']`
-- [ ] 20행 수정: `fetch('/api/categories')` → `fetch('/data/categories.json')`
-- [ ] 파일 저장
+- [x] `src/components/category-filter.tsx` 파일 열기
+- [x] 18행 수정: `queryKey: ['/api/categories']` → `queryKey: ['/data/categories']`
+- [x] 20행 수정: `fetch('/api/categories')` → `fetch('/data/categories.json')`
+- [x] 파일 저장
 
 ## Phase 2: 빌드 및 테스트
 
 ### Step 4: 로컬 빌드
-- [ ] 터미널에서 `npm run build` 실행
-- [ ] 빌드 성공 확인
-- [ ] `public/data/categories.json` 파일 생성 확인
+- [x] 터미널에서 `npm run build` 실행
+- [x] 빌드 성공 확인
+- [x] `public/data/categories.json` 파일 생성 확인
 
 ### Step 5: 로컬 서버 실행
-- [ ] 터미널에서 `npm run start` 실행
-- [ ] 서버 시작 확인 (http://localhost:3000)
+- [x] 터미널에서 `npm run start` 실행
+- [x] 서버 시작 확인 (http://localhost:3000)
 
 ### Step 6: 수동 기능 검증
-- [ ] 브라우저에서 http://localhost:3000 접속
-- [ ] Footer 섹션 스크롤
-- [ ] 카테고리 목록 표시 확인:
-  - [ ] Stock (61)
-  - [ ] Weekly (14)
-  - [ ] ETF (11)
-  - [ ] Etc (9)
-- [ ] 브라우저 개발자 도구 열기 (F12)
-- [ ] Network 탭 확인:
-  - [ ] `/data/categories.json` 요청 성공 (200)
-  - [ ] `/api/categories` 요청 없음 확인
-- [ ] 카테고리 링크 클릭 테스트:
-  - [ ] Stock 링크 클릭 → Stock 카테고리 필터링 확인
-  - [ ] Weekly 링크 클릭 → Weekly 카테고리 필터링 확인
+- [x] 브라우저에서 http://localhost:3000 접속
+- [x] Footer 섹션 스크롤
+- [x] 카테고리 목록 표시 확인:
+  - [x] Stock (61)
+  - [x] Weekly (14)
+  - [x] ETF (11)
+  - [x] Etc (9)
+- [x] 브라우저 개발자 도구 열기 (F12)
+- [x] Network 탭 확인:
+  - [x] `/data/categories.json` 요청 성공 (200)
+  - [x] `/api/categories` 요청 없음 확인
+- [x] 카테고리 링크 클릭 테스트:
+  - [x] Stock 링크 클릭 → Stock 카테고리 필터링 확인
+  - [x] Weekly 링크 클릭 → Weekly 카테고리 필터링 확인
 
 ### Step 7: MCP Playwright 자동 테스트
-- [ ] 로컬 서버 실행 상태 확인 (`npm run start`)
-- [ ] Playwright 테스트 실행:
-  - [ ] 홈페이지 접속: `navigate({ url: 'http://localhost:3000' })`
-  - [ ] 전체 페이지 스크린샷: `screenshot({ name: 'homepage-with-footer', fullPage: true })`
-  - [ ] Footer 텍스트 확인: `get_visible_text()` → "Stock", "Weekly", "ETF", "Etc" 포함 확인
-  - [ ] Stock 카테고리 클릭: `click({ selector: 'footer a[href*="category=Stock"]' })`
-  - [ ] 필터링 결과 스크린샷: `screenshot({ name: 'category-stock-filtered' })`
-  - [ ] 홈으로 돌아가기: `navigate({ url: 'http://localhost:3000' })`
-  - [ ] Weekly 카테고리 클릭: `click({ selector: 'footer a[href*="category=Weekly"]' })`
-  - [ ] 필터링 결과 스크린샷: `screenshot({ name: 'category-weekly-filtered' })`
-- [ ] 테스트 결과 확인:
-  - [ ] 모든 스크린샷에 카테고리 목록 표시됨
-  - [ ] 카테고리 필터링 정상 동작
-  - [ ] Console에 에러 없음
+- [x] 로컬 서버 실행 상태 확인 (`npm run start`)
+- [x] Playwright 테스트 실행:
+  - [x] 홈페이지 접속: `navigate({ url: 'http://localhost:3000' })`
+  - [x] 전체 페이지 스크린샷: `screenshot({ name: 'homepage-with-footer', fullPage: true })`
+  - [x] Footer 텍스트 확인: `get_visible_text()` → "Stock", "Weekly", "ETF", "Etc" 포함 확인
+  - [x] Stock 카테고리 클릭: `click({ selector: 'footer a[href*="category=Stock"]' })`
+  - [x] 필터링 결과 스크린샷: `screenshot({ name: 'category-stock-filtered' })`
+  - [x] 홈으로 돌아가기: `navigate({ url: 'http://localhost:3000' })`
+  - [x] Weekly 카테고리 클릭: `click({ selector: 'footer a[href*="category=Weekly"]' })`
+  - [x] 필터링 결과 스크린샷: `screenshot({ name: 'category-weekly-filtered' })`
+- [x] 테스트 결과 확인:
+  - [x] 모든 스크린샷에 카테고리 목록 표시됨
+  - [x] 카테고리 필터링 정상 동작
+  - [x] Console에 에러 없음
 
 ## Phase 3: 완료
 
 ### Step 8: 정리
-- [ ] 로컬 서버 종료 (Ctrl+C)
-- [ ] 변경사항 커밋 준비
+- [x] 로컬 서버 종료 (Ctrl+C)
+- [x] 변경사항 커밋 준비

--- a/src/components/category-filter.tsx
+++ b/src/components/category-filter.tsx
@@ -15,9 +15,9 @@ interface Category {
 export function CategoryFilter({ selectedCategory, onCategoryChange }: CategoryFilterProps) {
   // Fetch categories from API
   const { data: apiCategories } = useQuery<Category[]>({
-    queryKey: ['/api/categories'],
+    queryKey: ['/data/categories'],
     queryFn: async () => {
-      const response = await fetch('/api/categories');
+      const response = await fetch('/data/categories.json');
       if (!response.ok) {
         throw new Error('Failed to fetch categories');
       }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { ChartLine, Twitter, Linkedin, Youtube, Instagram, ExternalLink } from "lucide-react";
 import { useState, useEffect } from "react";
+import { getAllCategoriesClient } from "@/lib/blog-client";
 
 interface Category {
   category: string;
@@ -16,31 +17,7 @@ export function Footer() {
   console.log('Footer render - categories:', categories, 'type:', typeof categories, 'isArray:', Array.isArray(categories));
 
   useEffect(() => {
-    // Fetch categories on client side
-    const fetchCategories = async () => {
-      try {
-        const response = await fetch('/api/categories');
-        if (response.ok) {
-          const data = await response.json();
-          console.log('API response data:', data, 'type:', typeof data, 'isArray:', Array.isArray(data));
-          // Ensure data is an array before setting it
-          if (Array.isArray(data)) {
-            setCategories(data);
-          } else {
-            console.error('Categories API returned non-array data:', data);
-            setCategories([]);
-          }
-        } else {
-          console.error('Failed to fetch categories:', response.status);
-          setCategories([]);
-        }
-      } catch (error) {
-        console.error('Failed to fetch categories:', error);
-        setCategories([]);
-      }
-    };
-
-    fetchCategories();
+    getAllCategoriesClient().then(setCategories);
   }, []);
   return (
     <footer className="bg-gray-900 text-white py-12">

--- a/src/lib/blog-client.ts
+++ b/src/lib/blog-client.ts
@@ -18,7 +18,7 @@ export async function getAllBlogPostsClient(): Promise<BlogPost[]> {
 // Client-side function to get categories via API
 export async function getAllCategoriesClient(): Promise<Array<{ category: string; count: number }>> {
   try {
-    const response = await fetch('/api/categories')
+    const response = await fetch('/data/categories.json')
     if (!response.ok) {
       throw new Error('Failed to fetch categories')
     }


### PR DESCRIPTION
## 문제
- Footer에 "카테고리가 없습니다" 표시됨
- 원인: 정적 사이트인데 `/api/categories` API 엔드포인트 호출 (동작 안 함)

## 해결 방안
- 빌드 시 생성된 정적 JSON 파일(`/data/categories.json`) 직접 사용
- API Routes 호출을 정적 파일 fetch로 변경

## 수정 내용
### 코드 변경 (3개 파일)
- **src/lib/blog-client.ts**: `/api/categories` → `/data/categories.json`
- **src/components/footer.tsx**: import 추가 및 useEffect 로직 단순화 (27줄 코드 제거)
- **src/components/category-filter.tsx**: useQuery fetch URL 변경

### 테스트 결과
- ✅ 빌드 성공 (95 posts, 4 categories)
- ✅ categories.json 생성 확인
- ✅ Playwright 자동 테스트 통과
  - Footer에 카테고리 4개 표시 확인 (Stock, Weekly, ETF, Etc)
  - 카테고리 링크 클릭 시 필터링 정상 동작
  - `/data/categories.json` 요청 성공 (200 OK)
  - `/api/categories` 요청 없음 확인

## 예상 결과
Footer에 실제 카테고리 표시:
- Stock (61)
- Weekly (14)
- ETF (11)
- Etc (9)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)