### PR TITLE
[#45] robots.txt에서 Host 지시어 제거

### DIFF
--- a/scripts/generateRobots.ts
+++ b/scripts/generateRobots.ts
@@ -13,9 +13,6 @@ Disallow: /_next/
 
 Sitemap: ${baseUrl}/sitemap.xml
 
-# Host
-Host: ${baseUrl}
-
 # Investment Insights Blog
 # Professional financial blog about stocks, ETFs, bonds, and funds`;
 


### PR DESCRIPTION
* Host 섹션은 Google에서 공식적으로 지원하지 않는 비표준 규칙
* 깔끔한 robots.txt를 위해 불필요한 지시어 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
