### PR TITLE
fix: 깨진 HitCount 배지 제거

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -26,7 +26,6 @@ jobs:
             -e CONTENT_DIR=contents \
             -e BLOG_URL=https://investment.advenoh.pe.kr \
             -e PROJECT_TITLE="Frank's Investment Insights Blog" \
-            -e HITCOUNT_PATH=kenshin579/investment.advenoh.pe.kr \
             -e NETLIFY_BADGE_ID=359125d0-4402-402d-9168-5b48f60d6a6c \
             kenshin579/readme-generator:latest
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ generate-readme:
 		-e CONTENT_DIR=contents \
 		-e BLOG_URL=https://investment.advenoh.pe.kr \
 		-e PROJECT_TITLE="Frank's Investment Insights Blog" \
-		-e HITCOUNT_PATH=kenshin579/investment.advenoh.pe.kr \
 		-e NETLIFY_BADGE_ID=359125d0-4402-402d-9168-5b48f60d6a6c \
 		kenshin579/readme-generator:latest
 	@echo "README.md generated successfully!"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![HitCount](http://hits.dwyl.io/kenshin579/investment.advenoh.pe.kr.svg)](http://hits.dwyl.io/kenshin579/investment.advenoh.pe.kr)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/359125d0-4402-402d-9168-5b48f60d6a6c/deploy-status)](https://app.netlify.com/sites/advenoh/deploys)
 
 # Frank's Investment Insights Blog - Table of Contents


### PR DESCRIPTION
## Summary
- README.md에서 깨진 HitCount 배지 (`hits.dwyl.io`) 제거
- Makefile과 GitHub Actions에서 `HITCOUNT_PATH` 환경 변수 제거

## 변경 파일
- `README.md`: HitCount 배지 라인 삭제
- `Makefile`: HITCOUNT_PATH 환경 변수 삭제
- `.github/workflows/generate-readme.yml`: HITCOUNT_PATH 환경 변수 삭제

## Test plan
- [ ] `make generate-readme` 실행 시 HitCount 배지 없이 README 생성 확인

🤖 Generated with [Claude Code](https://claude.ai/code)