### PR TITLE
[#64] feat: Mermaid 다이어그램 렌더링 지원 추가

### DIFF
--- a/contents/etc/mermaid-diagram-sample/index.md
+++ b/contents/etc/mermaid-diagram-sample/index.md
@@ -1,0 +1,106 @@
+---
+title: "Mermaid 다이어그램 샘플"
+description: "블로그에서 Mermaid 다이어그램을 사용하는 방법과 다양한 다이어그램 유형 샘플입니다."
+date: 2025-01-23
+category: Etc
+tags:
+  - mermaid
+  - diagram
+  - 다이어그램
+  - sample
+---
+
+## Flowchart (흐름도)
+
+투자 의사결정 흐름도:
+
+```mermaid
+flowchart TD
+    A[종목 발굴] --> B{기본 분석 통과?}
+    B -->|Yes| C[재무제표 분석]
+    B -->|No| D[제외]
+    C --> E{적정 가치 대비 저평가?}
+    E -->|Yes| F[매수]
+    E -->|No| G[관심 종목 등록]
+    F --> H{목표가 도달?}
+    H -->|Yes| I[매도]
+    H -->|No| J[보유 유지]
+```
+
+## Sequence Diagram (시퀀스 다이어그램)
+
+주식 주문 처리 과정:
+
+```mermaid
+sequenceDiagram
+    participant 투자자
+    participant 증권사
+    participant 거래소
+    participant 결제원
+
+    투자자->>증권사: 매수 주문
+    증권사->>거래소: 주문 전송
+    거래소->>거래소: 매칭 처리
+    거래소-->>증권사: 체결 통보
+    증권사-->>투자자: 체결 알림
+    거래소->>결제원: 결제 요청 (T+2)
+    결제원-->>거래소: 결제 완료
+```
+
+## Pie Chart (파이 차트)
+
+포트폴리오 자산 배분:
+
+```mermaid
+pie title 자산 배분 비율
+    "국내 주식" : 30
+    "해외 주식" : 35
+    "채권" : 20
+    "현금성 자산" : 10
+    "대체 투자" : 5
+```
+
+## Gantt Chart (간트 차트)
+
+투자 리밸런싱 일정:
+
+```mermaid
+gantt
+    title 분기별 리밸런싱 계획
+    dateFormat  YYYY-MM-DD
+    section 1분기
+    포트폴리오 점검     :a1, 2025-01-01, 7d
+    리밸런싱 실행       :a2, after a1, 3d
+    section 2분기
+    포트폴리오 점검     :b1, 2025-04-01, 7d
+    리밸런싱 실행       :b2, after b1, 3d
+    section 3분기
+    포트폴리오 점검     :c1, 2025-07-01, 7d
+    리밸런싱 실행       :c2, after c1, 3d
+```
+
+## State Diagram (상태 다이어그램)
+
+주식 주문 상태 변화:
+
+```mermaid
+stateDiagram-v2
+    [*] --> 주문접수
+    주문접수 --> 대기중: 주문 전송
+    대기중 --> 체결: 매칭 성공
+    대기중 --> 부분체결: 일부 매칭
+    부분체결 --> 체결: 잔량 매칭
+    부분체결 --> 취소: 잔량 취소
+    대기중 --> 취소: 주문 취소
+    체결 --> [*]
+    취소 --> [*]
+```
+
+## 에러 케이스 (잘못된 문법)
+
+아래는 의도적으로 잘못된 Mermaid 문법입니다. 에러 메시지가 표시되어야 합니다:
+
+```mermaid
+invalid diagram syntax !!!
+this should show an error message
+```

--- a/docs/start/2_mermaid_implementation.md
+++ b/docs/start/2_mermaid_implementation.md
@@ -1,0 +1,123 @@
+# Mermaid Diagram 렌더링 - 구현 문서
+
+## 수정/생성 파일 목록
+
+| 파일 | 작업 | 설명 |
+|------|------|------|
+| `package.json` | 수정 | `mermaid` 패키지 추가 |
+| `src/components/mermaid-diagram.tsx` | 신규 | Mermaid 다이어그램 렌더링 컴포넌트 |
+| `src/components/markdown-renderer.tsx` | 수정 | 코드 블록에서 mermaid 분기 처리 |
+| `contents/etc/mermaid-diagram-sample/index.md` | 신규 | Mermaid 다이어그램 테스트용 샘플 포스트 |
+
+## 구현 상세
+
+### 1. 의존성 설치
+
+```bash
+npm install mermaid
+```
+
+### 2. MermaidDiagram 컴포넌트 (`src/components/mermaid-diagram.tsx`)
+
+```tsx
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface MermaidDiagramProps {
+  chart: string;
+}
+
+export function MermaidDiagram({ chart }: MermaidDiagramProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const renderDiagram = async () => {
+      try {
+        const mermaid = (await import('mermaid')).default;
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: 'default',
+          securityLevel: 'loose',
+        });
+
+        if (containerRef.current) {
+          const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
+          const { svg } = await mermaid.render(id, chart);
+          containerRef.current.innerHTML = svg;
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Mermaid 다이어그램 렌더링 실패');
+      }
+    };
+
+    renderDiagram();
+  }, [chart]);
+
+  if (error) {
+    return (
+      <div className="mb-4 p-4 border border-red-300 bg-red-50 rounded-lg">
+        <p className="text-red-600 text-sm font-medium">Mermaid 렌더링 오류</p>
+        <pre className="text-red-500 text-xs mt-2 whitespace-pre-wrap">{error}</pre>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="mb-4 flex justify-center overflow-x-auto"
+      aria-label={chart}
+    />
+  );
+}
+```
+
+핵심 포인트:
+- `'use client'` 지시어로 클라이언트 컴포넌트 선언
+- `import('mermaid')` 동적 import로 해당 페이지에서만 로드
+- `mermaid.render()`로 SVG 생성 후 innerHTML에 삽입
+- 에러 시 다이어그램 대신 에러 메시지 표시
+- `aria-label`에 원본 코드 제공 (접근성)
+
+### 3. MarkdownRenderer 수정 (`src/components/markdown-renderer.tsx`)
+
+기존 `code` 컴포넌트 렌더러에서 `language === 'mermaid'` 분기 추가:
+
+```tsx
+import { MermaidDiagram } from './mermaid-diagram';
+
+// code 컴포넌트 내부
+code: (props: any) => {
+  const { inline, children, className, ...rest } = props;
+  const match = /language-(\w+)/.exec(className || '');
+  const language = match ? match[1] : '';
+
+  // mermaid 코드 블록 처리
+  if (!inline && language === 'mermaid') {
+    return <MermaidDiagram chart={String(children).replace(/\n$/, '')} />;
+  }
+
+  return !inline && match ? (
+    <SyntaxHighlighter ... />
+  ) : (
+    <code ... />
+  );
+},
+```
+
+변경점:
+- `MermaidDiagram` import 추가
+- `language === 'mermaid'` 조건 분기를 SyntaxHighlighter 앞에 배치
+
+### 4. 테스트용 샘플 포스트 (`contents/etc/mermaid-diagram-sample/index.md`)
+
+다양한 다이어그램 유형을 포함한 샘플 블로그 포스트:
+
+- **Flowchart**: 투자 의사결정 흐름도
+- **Sequence Diagram**: 주식 주문 처리 과정
+- **Pie Chart**: 포트폴리오 자산 배분
+- **Gantt Chart**: 리밸런싱 일정
+- **State Diagram**: 주문 상태 변화
+- **에러 케이스**: 잘못된 문법으로 에러 처리 동작 확인

--- a/docs/start/2_mermaid_prd.md
+++ b/docs/start/2_mermaid_prd.md
@@ -1,0 +1,89 @@
+# Mermaid Diagram 렌더링 지원 PRD
+
+## 배경
+
+현재 블로그의 마크다운 렌더링 파이프라인:
+- `react-markdown` + `remark-gfm` + `rehype-raw` 조합으로 클라이언트 사이드 렌더링
+- 코드 블록은 `react-syntax-highlighter`(Prism)로 구문 강조 처리
+- Mermaid, LaTeX 등 확장 문법은 미지원 상태
+
+## 목표
+
+마크다운 파일에서 ` ```mermaid ` 코드 블록을 작성하면 다이어그램으로 렌더링되도록 지원한다.
+
+### 지원 대상 다이어그램 유형
+- Flowchart (흐름도)
+- Sequence Diagram (시퀀스 다이어그램)
+- Class Diagram (클래스 다이어그램)
+- State Diagram (상태 다이어그램)
+- Gantt Chart (간트 차트)
+- Pie Chart (파이 차트)
+- ER Diagram (ER 다이어그램)
+
+## 요구사항
+
+### 기능 요구사항
+
+1. **마크다운 코드 블록 인식**
+   - ` ```mermaid ` 로 시작하는 코드 블록을 Mermaid 다이어그램으로 렌더링
+   - 일반 코드 블록(`js`, `python` 등)은 기존 구문 강조 유지
+
+2. **렌더링 품질**
+   - SVG 기반 렌더링으로 선명한 출력
+   - 반응형 지원 (모바일/데스크톱 모두 가독성 확보)
+   - 다크/라이트 테마 대응 불필요 (현재 라이트 테마만 사용)
+
+3. **에러 처리**
+   - 잘못된 Mermaid 문법 작성 시 에러 메시지 표시 (다이어그램 대신)
+   - 페이지 전체가 깨지지 않도록 격리
+
+### 비기능 요구사항
+
+1. **성능**
+   - Mermaid 라이브러리는 해당 코드 블록이 있는 페이지에서만 로드 (동적 import)
+   - 초기 번들 사이즈 증가 최소화
+
+2. **정적 사이트 호환**
+   - `output: 'export'` 설정과 호환 (SSG 빌드 정상 동작)
+   - 클라이언트 사이드 렌더링으로 구현
+
+3. **접근성**
+   - 다이어그램에 대한 대체 텍스트 제공 (원본 Mermaid 코드를 aria-label 또는 접근 가능한 형태로)
+
+## 기술 구현 방향
+
+### 접근 방식: 클라이언트 사이드 렌더링
+
+`react-markdown`의 커스텀 컴포넌트 렌더러에서 `language === 'mermaid'`인 코드 블록을 별도 Mermaid 컴포넌트로 위임한다.
+
+### 수정 대상 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `src/components/markdown-renderer.tsx` | 코드 블록 렌더러에서 mermaid 언어 분기 추가 |
+| `src/components/mermaid-diagram.tsx` | 신규 - Mermaid 다이어그램 렌더링 컴포넌트 |
+| `package.json` | `mermaid` 패키지 추가 |
+
+### 구현 단계
+
+1. **의존성 설치**: `mermaid` 패키지 추가
+2. **Mermaid 컴포넌트 생성**: `src/components/mermaid-diagram.tsx`
+   - `mermaid` 라이브러리를 동적 import
+   - `useEffect`에서 다이어그램 렌더링
+   - 에러 바운더리 포함
+3. **MarkdownRenderer 수정**: 코드 블록 렌더러에 mermaid 분기 추가
+4. **테스트용 마크다운 작성**: 샘플 블로그 포스트에 mermaid 코드 블록 추가하여 검증
+
+## 테스트 기준
+
+- [ ] ` ```mermaid ` 코드 블록이 다이어그램으로 렌더링됨
+- [ ] 일반 코드 블록(js, python 등)은 기존과 동일하게 구문 강조됨
+- [ ] 잘못된 Mermaid 문법 시 에러 메시지 표시 (페이지 미깨짐)
+- [ ] `npm run build` 정상 동작 (정적 빌드 호환)
+- [ ] 모바일 뷰에서 다이어그램 가독성 확인
+- [ ] Mermaid 코드 블록이 없는 페이지에서는 mermaid 라이브러리 미로드
+
+## 참고
+
+- Mermaid 공식 문서: https://mermaid.js.org/
+- react-markdown 커스텀 컴포넌트: https://github.com/remarkjs/react-markdown#components

--- a/docs/start/2_mermaid_todo.md
+++ b/docs/start/2_mermaid_todo.md
@@ -1,0 +1,45 @@
+# Mermaid Diagram 렌더링 - TODO
+
+## 1단계: 의존성 설치
+
+- [x] `npm install mermaid` 실행
+
+## 2단계: MermaidDiagram 컴포넌트 생성
+
+- [x] `src/components/mermaid-diagram.tsx` 생성
+  - [x] 동적 import로 mermaid 로드
+  - [x] useEffect에서 SVG 렌더링
+  - [x] 에러 상태 처리 (에러 메시지 UI)
+  - [x] aria-label로 접근성 대체 텍스트 제공
+  - [x] 반응형 컨테이너 (overflow-x-auto)
+
+## 3단계: MarkdownRenderer 수정
+
+- [x] `src/components/markdown-renderer.tsx` 수정
+  - [x] `MermaidDiagram` import 추가
+  - [x] code 렌더러에서 `language === 'mermaid'` 분기 추가
+
+## 4단계: 샘플 포스트 작성
+
+- [x] `contents/etc/mermaid-diagram-sample/index.md` 생성
+  - [x] Flowchart (투자 의사결정 흐름도)
+  - [x] Sequence Diagram (주식 주문 처리)
+  - [x] Pie Chart (포트폴리오 자산 배분)
+  - [x] Gantt Chart (리밸런싱 일정)
+  - [x] State Diagram (주문 상태 변화)
+  - [x] 에러 케이스 (잘못된 문법)
+
+## 5단계: 빌드 검증
+
+- [x] `npm run check` 타입 체크 통과
+- [x] `npm run build` 정적 빌드 정상 동작
+- [x] 샘플 포스트가 정상적으로 빌드에 포함되는지 확인
+
+## 6단계: 테스트 (MCP Playwright)
+
+- [x] `npm run start`로 로컬 서버 실행
+- [x] 샘플 포스트 접속: `http://localhost:3000/etc/mermaid-diagram-sample`
+- [x] 다이어그램이 SVG로 렌더링되는지 스크린샷 확인
+- [x] 잘못된 Mermaid 문법 시 에러 메시지 표시 확인
+- [ ] 일반 코드 블록(js, python 등) 구문 강조 정상 동작 확인
+- [ ] Mermaid 없는 페이지에서 mermaid 라이브러리 미로드 확인 (Network 탭)

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gray-matter": "^4.0.3",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.532.0",
+    "mermaid": "^11.12.2",
     "next": "^16.0.8",
     "next-themes": "^0.4.6",
     "passport-local": "^1.0.0",

--- a/src/components/markdown-renderer.tsx
+++ b/src/components/markdown-renderer.tsx
@@ -4,6 +4,7 @@ import rehypeRaw from "rehype-raw";
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { tomorrow } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { MarkdownImage } from './markdown-image';
+import { MermaidDiagram } from './mermaid-diagram';
 
 interface MarkdownRendererProps {
   content: string;
@@ -125,7 +126,11 @@ export function MarkdownRenderer({ content, className = "", slug, category }: Ma
             const { inline, children, className, ...rest } = props;
             const match = /language-(\w+)/.exec(className || '');
             const language = match ? match[1] : '';
-            
+
+            if (!inline && language === 'mermaid') {
+              return <MermaidDiagram chart={String(children).replace(/\n$/, '')} />;
+            }
+
             return !inline && match ? (
               <SyntaxHighlighter
                 style={tomorrow}

--- a/src/components/mermaid-diagram.tsx
+++ b/src/components/mermaid-diagram.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface MermaidDiagramProps {
+  chart: string;
+}
+
+export function MermaidDiagram({ chart }: MermaidDiagramProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const renderDiagram = async () => {
+      try {
+        const mermaid = (await import('mermaid')).default;
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: 'default',
+          securityLevel: 'loose',
+        });
+
+        if (containerRef.current) {
+          const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
+          const { svg } = await mermaid.render(id, chart);
+          containerRef.current.innerHTML = svg;
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Mermaid 다이어그램 렌더링 실패');
+      }
+    };
+
+    renderDiagram();
+  }, [chart]);
+
+  if (error) {
+    return (
+      <div className="mb-4 p-4 border border-red-300 bg-red-50 rounded-lg">
+        <p className="text-red-600 text-sm font-medium">Mermaid 렌더링 오류</p>
+        <pre className="text-red-500 text-xs mt-2 whitespace-pre-wrap">{error}</pre>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="mb-4 flex justify-center overflow-x-auto"
+      aria-label={chart}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- 마크다운 코드 블록에서 `mermaid` 언어를 감지하여 다이어그램으로 렌더링
- `mermaid` 라이브러리 동적 import로 번들 사이즈 영향 최소화
- 잘못된 문법 시 에러 메시지 표시 (페이지 깨짐 방지)

## 변경사항
- `src/components/mermaid-diagram.tsx`: Mermaid 렌더링 컴포넌트 (동적 import, 에러 처리, aria-label)
- `src/components/markdown-renderer.tsx`: 코드 블록에서 mermaid 분기 추가
- `contents/etc/mermaid-diagram-sample/index.md`: 테스트용 샘플 포스트 (Flowchart, Sequence, Pie, Gantt, State, 에러 케이스)

## Test plan
- [x] `npm run build` 정적 빌드 정상 동작
- [x] Flowchart, Sequence, Pie, Gantt, State 다이어그램 SVG 렌더링 확인
- [x] 잘못된 Mermaid 문법 시 에러 메시지 표시 확인
- [ ] 일반 코드 블록 구문 강조 정상 동작 확인
- [ ] Mermaid 없는 페이지에서 라이브러리 미로드 확인

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)