### PR TITLE
[chore] fix-future-date 워크플로우 permissions 추가

### DIFF
--- a/.github/workflows/fix-future-date.yml
+++ b/.github/workflows/fix-future-date.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   fix-date:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary
- fix-future-date reusable workflow 호출 시 권한 부족 오류 수정
- caller 워크플로우에 `contents: write`, `pull-requests: write` permissions 추가

## Test plan
- [ ] PR merge 시 fix-future-date 워크플로우가 정상 실행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)