### PR TITLE
fix: fix-future-date 워크플로우에 content_dir 지정

### DIFF
--- a/.github/workflows/fix-future-date.yml
+++ b/.github/workflows/fix-future-date.yml
@@ -14,4 +14,5 @@ jobs:
     uses: kenshin579/actions/.github/workflows/fix-future-date.yml@main
     with:
       pr_number: ${{ github.event.pull_request.number }}
+      content_dir: contents
     secrets: inherit


### PR DESCRIPTION
## Summary
- fix-future-date 워크플로우에 `content_dir: contents` 파라미터 추가
- `contents/` 폴더의 `index.md`만 미래 날짜 보정 대상으로 제한
- `docs/start/` 등 작업 문서가 불필요하게 보정되는 문제 수정 (PR #87 원인)

## Test plan
- [ ] PR merge 시 `docs/start/`의 미래 날짜 파일이 보정되지 않는지 확인
- [ ] `contents/`의 미래 날짜 파일은 정상적으로 보정되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)