### PR TITLE
[#131] fix: TOC 컴포넌트에 누락된 ReactMarkdown 닫는 태그 추가

### DIFF
--- a/src/components/table-of-contents.tsx
+++ b/src/components/table-of-contents.tsx
@@ -137,6 +137,7 @@ export function TableOfContents({ content, className = "" }: TableOfContentsProp
                   }}
                 >
                   {item.text.replace(/^(\d+)\.\s/, '$1\\. ')}
+                </ReactMarkdown>
               </button>
             ))}
           </nav>


### PR DESCRIPTION
## Summary
- \`table-of-contents.tsx\`에서 \`<ReactMarkdown>\` 여는 태그는 있으나 닫는 태그 \`</ReactMarkdown>\`가 누락되어 Turbopack 빌드가 실패하던 문제 수정
- 1줄 추가

## 배경
PR #126 (\`f8a34ae\`, 2026-03-17) 머지 이후 이 파일이 변경되지 않았고 투자 블로그가 재배포된 적이 없어 이번 PR #128 CORS 머지로 처음 production 빌드가 트리거되면서 드러남.

## Test plan
- [ ] Netlify Deploy Preview 빌드 성공 확인
- [ ] 머지 후 production 배포 성공 확인
- [ ] 블로그 글 상세 페이지에서 TOC 정상 렌더 확인
- [ ] \`curl -sI https://investment.advenoh.pe.kr/rss.xml | grep -i access-control\` 로 CORS 헤더 (#128) 반영도 함께 검증

Closes #131