### PR TITLE
RSS 피드에서도 History 제외

### DIFF
--- a/scripts/generateRssFeed.ts
+++ b/scripts/generateRssFeed.ts
@@ -18,8 +18,15 @@ async function generateRssFeed() {
 
   const baseUrl = process.env.SITE_URL || 'https://investment.advenoh.pe.kr';
 
+  // 선별 규칙은 src/app/rss.xml/route.ts 와 반드시 같아야 한다.
+  // 그 라우트가 out/rss.xml 을 만들며 이 파일이 쓴 public/rss.xml 을 가리기 때문에,
+  // 한쪽만 고치면 배포된 피드는 안 바뀐다. 실제로 그렇게 사고가 났었다.
+  //
+  //  - stub: 본문 없이 frontmatter 만 채운 타임라인 사건 글
+  //  - History: 사건 14개가 모두 같은 날짜라 최신 20칸을 통째로 차지한다. 제자리는 /timeline
   const sortedPosts = posts
     .filter((post) => post.stub !== true)
+    .filter((post) => !post.categories?.some((c) => c.toLowerCase() === 'history'))
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     .slice(0, 20);
 

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -8,10 +8,15 @@ export async function GET() {
   const baseUrl = process.env.SITE_URL || 'https://investment.advenoh.pe.kr'
 
   // 이 라우트 핸들러가 out/rss.xml 을 만들면서 scripts/generateRssFeed.ts 가 쓴
-  // public/rss.xml 을 가린다. 그래서 필터·정렬·개수 제한을 여기에도 똑같이 둬야 한다.
-  // (stub 은 본문 없이 frontmatter 만 채운 타임라인 사건 글이다. 피드에 나가면 안 된다.)
+  // public/rss.xml 을 가린다. 그래서 아래 선별 규칙을 두 곳에 똑같이 둬야 한다.
+  // 한쪽만 고쳤다가 실제로 사고가 났었다. 여기를 고치면 저기도 고칠 것.
+  //
+  //  - stub: 본문 없이 frontmatter 만 채운 타임라인 사건 글. 피드에 나가면 안 된다.
+  //  - History: 사건 14개가 모두 같은 날짜라, 두면 최신 20칸을 통째로 차지한다.
+  //    이 글들의 제자리는 /timeline 이다. 홈 기본 목록에서 빼는 것과 같은 이유다.
   const posts = allPosts
     .filter(post => post.stub !== true)
+    .filter(post => !post.categories?.some(c => c.toLowerCase() === 'history'))
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     .slice(0, 20)
 


### PR DESCRIPTION
## Summary

[#152](https://github.com/kenshin579/investment.advenoh.pe.kr/pull/152)에서 홈 기본 목록에 적용한 규칙을 RSS에도 맞췄다.

사건 14개가 모두 같은 날짜라 **RSS 20칸 중 14칸을 History가 차지하고 있었다.** 구독자에게는 다른 카테고리 글이 거의 보이지 않는 상태였다. 이 글들의 제자리는 `/timeline` 이다.

| | 변경 전 | 변경 후 |
|---|---|---|
| 전체 항목 | 20 | 20 |
| History | **14** | **0** |
| Etc / Stock / Weekly | 6 | **20** |

## 두 파일을 함께 고친 이유

`src/app/rss.xml/route.ts` 가 만드는 `out/rss.xml` 이 `scripts/generateRssFeed.ts` 가 쓴 `public/rss.xml` 을 가린다. **한쪽만 고치면 배포된 피드는 바뀌지 않는다** — 예전에 stub 필터를 스크립트에만 넣었다가 실제로 그렇게 사고가 났다.

두 파일에 같은 선별 규칙을 두고, 서로를 가리키는 주석을 남겼다.

## 사이트맵은 건드리지 않았다

사이트맵은 검색엔진용이라 모든 페이지가 들어 있어야 한다. History 14건 + `/timeline` 그대로 유지된다.

## Test plan

- [x] `npm run check:scripts` — 통과
- [x] `npm run check` — 에러 11건, 기존 베이스라인과 동일
- [x] `npm run build` — 통과
- [x] `out/rss.xml` — 20건, history 0건 (Etc 4 · Stock 8 · Weekly 8)
- [x] `public/rss.xml` — 20건, history 0건 (두 산출물이 같은 규칙인지 확인)
- [x] RSS XML 파싱 검증 통과, HTTP 200
- [x] `sitemap.xml` — history 14건 유지, 전체 116 URL 변동 없음